### PR TITLE
Made MonadError instance Overlappable

### DIFF
--- a/src/Control/Monad/TestFixture.hs
+++ b/src/Control/Monad/TestFixture.hs
@@ -252,7 +252,7 @@ newtype TestFixtureT fixture log state m a = TestFixtureT { getRWST :: RWST (fix
 instance MonadTrans (TestFixtureT fixture log state) where
   lift = TestFixtureT . lift
 
-instance MonadError e m => MonadError e (TestFixtureT fixture log state m) where
+instance {-# OVERLAPPABLE #-} MonadError e m => MonadError e (TestFixtureT fixture log state m) where
   throwError = lift . throwError
   catchError m h = TestFixtureT (getRWST m `catchError` \e -> getRWST (h e))
 

--- a/src/Control/Monad/TestFixture/TH/Internal.hs
+++ b/src/Control/Monad/TestFixture/TH/Internal.hs
@@ -12,7 +12,7 @@ import qualified Control.Monad.Fail as Fail
 #endif
 import qualified Control.Monad.Reader as Reader
 
-import Prelude hiding (log)
+import Prelude hiding (log, MonadFail)
 import Control.Monad (join, replicateM, when, zipWithM)
 import Control.Monad.TestFixture (TestFixture, TestFixtureT, unimplemented)
 import Data.Char (isPunctuation, isSymbol)

--- a/stack-18.0.yaml
+++ b/stack-18.0.yaml
@@ -1,0 +1,13 @@
+resolver:
+  lts-18.0
+
+packages:
+- '.'
+
+extra-deps: []
+
+flags:
+  {}
+
+extra-package-dbs:
+  []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.0.yaml
+stack-18.0.yaml

--- a/test-fixture.cabal
+++ b/test-fixture.cabal
@@ -45,7 +45,7 @@ library
     , haskell-src-exts
     , haskell-src-meta
     , mtl
-    , template-haskell >= 2.10 && < 2.13
+    , template-haskell >= 2.10 && < 2.17
     , th-orphans
   if impl(ghc < 8)
     build-depends:


### PR DESCRIPTION
If you are making a test fixture that uses `MonadError` you have to use the language extension `OverlappingInstances` which is now deprecated. Defining this instance as `OVERLAPPABLE` removes this requirement.

I ran into this issue when trying to create a fixture that included `MonadError`

```haskell
mkFixture "FixtureInst" [ts| MonadError ErrorType, MonadDate |]
```

and then ran unit test code that used the fixture

```haskell
        describe "convertToDate" $ do
          let day = fromGregorian 2017 3 13
          let date = UTCTime { utctDay = day, utctDayTime = secondsToDiffTime 43200 }
          let fixture = def { _getDay = return day 
                            , _getUTCTime = return date
                            }   
   
          it "Matches 'today'" $ do
            let res = unTestFixture (convertToDate "today") fixture
            res `shouldBe` (fromGregorian 2017 3 13) 
```

for code that uses `MonadError`

```haskell
data ErrorType
  = EInvalidIndex Int 
  | EInvalidIndexes [Int]
  | EInvalidArg Text
  | EIOError E.IOException
  | EMiscError Text
  | EParseError PE.ParseError
  | EShortCircuit Text
  deriving (Show, Eq) 
         
type AppError = MonadError ErrorType 


convertToDate :: (AppError m, MonadDate m) => String -> m Day                                                                                                                                                                                                                                                            
  convertToDate str 
    | dayString == "today" = getDay
    | dayString == "tomorrow" = getDay >>= (return . addDays 1)
    | dayString == "yesterday" = getDay >>= (return . addDays (-1))
    | dayString == "monday" = getDay >>= dayOfWeek 1
    | dayString == "mon" = getDay >>= dayOfWeek 1
    | dayString == "tuesday" = getDay >>= dayOfWeek 2
    | dayString == "tue" = getDay >>= dayOfWeek 2
    | dayString == "wednesday" = getDay >>= dayOfWeek 3
    | dayString == "wed" = getDay >>= dayOfWeek 3
    | dayString == "thursday" = getDay >>= dayOfWeek 4
    | dayString == "thu" = getDay >>= dayOfWeek 4
    | dayString == "friday" = getDay >>= dayOfWeek 5
    | dayString == "fri" = getDay >>= dayOfWeek 5
    | dayString == "saturday" = getDay >>= dayOfWeek 6
    | dayString == "sat" = getDay >>= dayOfWeek 6
    | dayString == "sunday" = getDay >>= dayOfWeek 7
    | dayString == "sun" = getDay >>= dayOfWeek 7
    | otherwise = throwError . EMiscError . T.pack $ "invalid relative date '" ++ str ++ "'" 
    where
      dayString = map toLower str 
      dayOfWeek off day = do
        let (yr,wk,wday) = toWeekDate day 
        if (off <= wday)
        then return . addDays 7 $ fromWeekDate yr wk off 
        else return $ fromWeekDate yr wk off 
```

which results in the following error

```
todo.hs/test/Todo/TasksSpec.hs:117:36: error:
    • Overlapping instances for MonadError
                                  ErrorType
                                  (TestFixtureT FixtureInst () () Data.Functor.Identity.Identity)
        arising from a use of ‘convertToDate’
      Matching instances:
        instance MonadError e m =>
                 MonadError e (TestFixtureT fixture log state m)
          -- Defined in ‘Control.Monad.TestFixture’
        instance Monad m =>
                 MonadError ErrorType (TestFixtureT FixtureInst w s m)
          -- Defined at test/Todo/TasksSpec.hs:26:1
    • In the first argument of ‘unTestFixture’, namely
        ‘(convertToDate "today")’
      In the expression: unTestFixture (convertToDate "today") fixture
      In an equation for ‘res’:
          res = unTestFixture (convertToDate "today") fixture
    |
117 |           let res = unTestFixture (convertToDate "today") fixture
    |                                    ^^^^^^^^
```